### PR TITLE
Move Infinite Recursion Fixes Over From Private Repo

### DIFF
--- a/frontend/src/components/annotations/AnnotationCards.tsx
+++ b/frontend/src/components/annotations/AnnotationCards.tsx
@@ -122,10 +122,17 @@ export const AnnotationCards = ({
               content={item.rawText}
               trigger={<p>{item.rawText?.substring(0, 256)}</p>}
             />
-            <Popup
-              content={item.document.title}
-              trigger={<Label corner="right" icon="file text outline" />}
-            />
+            {item && item.document && item.corpus ? (
+              <Popup
+                content={item.document.title}
+                trigger={<Label corner="right" icon="file text outline" />}
+              />
+            ) : (
+              <Popup
+                content={"Missing document for item!"}
+                trigger={<Label corner="right" icon="file text outline" />}
+              />
+            )}
           </Card.Content>
         </Card>
       );

--- a/frontend/src/components/annotations/CorpusAnnotationCards.tsx
+++ b/frontend/src/components/annotations/CorpusAnnotationCards.tsx
@@ -1,0 +1,131 @@
+import { useEffect } from "react";
+
+import _ from "lodash";
+import { toast } from "react-toastify";
+import { useQuery, useReactiveVar } from "@apollo/client";
+import { useLocation } from "react-router-dom";
+
+import { AnnotationCards } from "./AnnotationCards";
+
+import {
+  authToken,
+  annotationContentSearchTerm,
+  filterToLabelsetId,
+  filterToLabelId,
+} from "../../graphql/cache";
+
+import {
+  GetAnnotationsInputs,
+  GetAnnotationsOutputs,
+  GET_ANNOTATIONS,
+} from "../../graphql/queries";
+import { ServerAnnotationType } from "../../graphql/types";
+
+export const CorpusAnnotationCards = ({
+  opened_corpus_id,
+}: {
+  opened_corpus_id: string | null;
+}) => {
+  /**
+   * This component wraps the CorpusCards component (which is a pure rendering component)
+   * with some query logic for a given corpus_id. If the corpus_id is passed in, it will
+   * query for the annotations for that corpus and let you browse them.
+   */
+
+  const auth_token = useReactiveVar(authToken);
+  const annotation_search_term = useReactiveVar(annotationContentSearchTerm);
+  const filter_to_labelset_id = useReactiveVar(filterToLabelsetId);
+  const filter_to_label_id = useReactiveVar(filterToLabelId);
+
+  const location = useLocation();
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Query to get annotations
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  const {
+    refetch: refetchAnnotations,
+    loading: annotation_loading,
+    error: annotation_error,
+    data: annotation_response,
+    fetchMore: fetchMoreAnnotations,
+  } = useQuery<GetAnnotationsOutputs, GetAnnotationsInputs>(GET_ANNOTATIONS, {
+    notifyOnNetworkStatusChange: true, // necessary in order to trigger loading signal on fetchMore
+    variables: {
+      annotationLabel_Type: "TOKEN_LABEL",
+      ...(opened_corpus_id ? { corpusId: opened_corpus_id } : {}),
+      ...(filter_to_label_id ? { annotationLabelId: filter_to_label_id } : {}),
+      ...(filter_to_labelset_id
+        ? { usesLabelFromLabelsetId: filter_to_labelset_id }
+        : {}),
+      ...(annotation_search_term
+        ? { rawText_Contains: annotation_search_term }
+        : {}),
+    },
+  });
+  if (annotation_error) {
+    toast.error("ERROR\nCould not fetch annotations for corpus.");
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Effects to reload data on certain changes
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // If user logs in while on this page... refetch to get their authorized corpuses
+  useEffect(() => {
+    console.log("Auth token change", auth_token);
+    if (auth_token && opened_corpus_id) {
+      refetchAnnotations();
+    }
+  }, [auth_token]);
+
+  useEffect(() => {
+    console.log("filter_to_label_id changed");
+    if (filter_to_label_id && opened_corpus_id) {
+      refetchAnnotations();
+    }
+  }, [filter_to_label_id]);
+
+  // If we detech user navigated to this page, refetch
+  useEffect(() => {
+    console.log(
+      "CorpusAnnotationCards checking location pathname",
+      location.pathname
+    );
+    if (opened_corpus_id && location.pathname === "/corpuses") {
+      refetchAnnotations();
+    }
+  }, [location]);
+
+  useEffect(() => {
+    console.log("Opened corpus");
+    if (opened_corpus_id) {
+      refetchAnnotations();
+    }
+  }, [opened_corpus_id]);
+
+  useEffect(() => {
+    console.log("Annotation search term changed...");
+    refetchAnnotations();
+  }, [annotation_search_term]);
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Query to shape item data
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  const annotation_data = annotation_response?.annotations?.edges
+    ? annotation_response.annotations.edges
+    : [];
+  const annotation_items = annotation_data
+    .map((edge) => (edge ? edge.node : undefined))
+    .filter((item): item is ServerAnnotationType => !!item);
+
+  return (
+    <AnnotationCards
+      items={annotation_items}
+      loading={annotation_loading}
+      loading_message="Annotations Loading..."
+      pageInfo={undefined}
+      //pageInfo={annotation_response?.annotations?.pageInfo ? annotation_response.annotations.pageInfo : undefined}
+      style={{ minHeight: "70vh" }}
+      fetchMore={fetchMoreAnnotations}
+    />
+  );
+};

--- a/frontend/src/components/annotator/Annotator.tsx
+++ b/frontend/src/components/annotator/Annotator.tsx
@@ -138,6 +138,8 @@ export const Annotator = ({
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
+  // console.log("Annotation - openedDocument: ", openedDocument);
+
   let doc_permissions: PermissionTypes[] = [];
   let raw_permissions = openedDocument.myPermissions;
   if (openedDocument && raw_permissions !== undefined) {
@@ -168,7 +170,7 @@ export const Annotator = ({
   const textSearchElementRefs = useRef({});
 
   const handleKeyUpPress = useCallback((event) => {
-    const { key, keyCode } = event;
+    const { keyCode } = event;
     if (keyCode === 16) {
       //console.log("Shift released");
       setShiftDown(false);
@@ -176,7 +178,7 @@ export const Annotator = ({
   }, []);
 
   const handleKeyDownPress = useCallback((event) => {
-    const { key, keyCode } = event;
+    const { keyCode } = event;
     if (keyCode === 16) {
       //console.log("Shift depressed")
       setShiftDown(true);
@@ -192,8 +194,21 @@ export const Annotator = ({
     };
   }, [handleKeyUpPress, handleKeyDownPress]);
 
-  // Get the basic data PAWLS needs to render doc and start annotations:
-  const { loading, error, data, refetch } = useQuery<
+  useEffect(() => {
+    console.log("Annotator setup");
+  }, []);
+
+  // TODO - source of infinite loop is notifyOnNetworkStatusChange: true...
+  // somewhere it's triggering reloads... which is weird because we're not using loading
+  // flag...
+
+  // IT IS NOT TRIGGERING RELOAD... IT's JUST STOPPING SCREEN FROM REFRESH
+  const {
+    refetch: refetch_annotator,
+    loading: annotator_loading,
+    data: annotator_data,
+    error: annotator_error,
+  } = useQuery<
     RequestAnnotatorDataForDocumentOutputs,
     RequestAnnotatorDataForDocumentInputs
   >(REQUEST_ANNOTATOR_DATA_FOR_DOCUMENT, {
@@ -205,6 +220,7 @@ export const Annotator = ({
   });
 
   useEffect(() => {
+    console.log("Anotator - openedDocument changed");
     if (openedDocument && openedDocument.pdfFile) {
       setViewState(ViewState.LOADING);
 
@@ -235,7 +251,6 @@ export const Annotator = ({
           // first, visible page. That said it makes the code simpler, so we're ok with it for
           // now.
           const loadPages: Promise<PDFPageInfo>[] = [];
-          let total_char_count = 0;
           for (let i = 1; i <= doc.numPages; i++) {
             // See line 50 for an explanation of the cast here.
             loadPages.push(
@@ -256,7 +271,7 @@ export const Annotator = ({
         .then((pages) => {
           setPages(pages);
 
-          let { doc_text, page_text_map, string_index_token_map } =
+          let { doc_text, string_index_token_map } =
             createTokenStringSearch(pages);
 
           setPageTextMaps({
@@ -283,13 +298,13 @@ export const Annotator = ({
   }, [openedDocument]);
 
   useEffect(() => {
-    if (data) {
+    if (annotator_data) {
       // Build proper span label objs from GraphQL results
       let span_label_lookup: LooseObject = {};
-      if (data?.corpus?.labelSet) {
+      if (annotator_data?.corpus?.labelSet) {
         span_label_lookup = {
           ...span_label_lookup,
-          ...data.corpus.labelSet.spanLabels.edges.reduce(function (
+          ...annotator_data.corpus.labelSet.spanLabels.edges.reduce(function (
             obj: Record<string, any>,
             edge
           ) {
@@ -311,24 +326,23 @@ export const Annotator = ({
 
       // Build proper relationship label objs from GraphQL results
       let relationship_label_lookup: LooseObject = {};
-      if (data?.corpus?.labelSet?.relationshipLabels?.edges) {
+      if (annotator_data?.corpus?.labelSet?.relationshipLabels?.edges) {
         relationship_label_lookup = {
           ...relationship_label_lookup,
-          ...data.corpus.labelSet.relationshipLabels.edges.reduce(function (
-            obj: Record<string, any>,
-            edge
-          ) {
-            obj[edge.node.id] = {
-              id: edge.node.id,
-              color: edge.node.color,
-              text: edge.node.text,
-              icon: edge.node.icon as SemanticICONS,
-              description: edge.node.description,
-              labelType: edge.node.labelType,
-            };
-            return obj;
-          },
-          {}),
+          ...annotator_data.corpus.labelSet.relationshipLabels.edges.reduce(
+            function (obj: Record<string, any>, edge) {
+              obj[edge.node.id] = {
+                id: edge.node.id,
+                color: edge.node.color,
+                text: edge.node.text,
+                icon: edge.node.icon as SemanticICONS,
+                description: edge.node.description,
+                labelType: edge.node.labelType,
+              };
+              return obj;
+            },
+            {}
+          ),
         };
       }
       setRelationLabels(Object.values(relationship_label_lookup));
@@ -336,30 +350,29 @@ export const Annotator = ({
       // Build proper doc type label objs from GraphQL results
       let document_label_lookup: LooseObject = {};
 
-      if (data?.corpus?.labelSet?.docTypeLabels?.edges) {
+      if (annotator_data?.corpus?.labelSet?.docTypeLabels?.edges) {
         document_label_lookup = {
           ...document_label_lookup,
-          ...data.corpus.labelSet.docTypeLabels.edges.reduce(function (
-            obj: Record<string, any>,
-            edge
-          ) {
-            obj[edge.node.id] = {
-              id: edge.node.id,
-              color: edge.node.color,
-              text: edge.node.text,
-              icon: edge.node.icon as SemanticICONS,
-              description: edge.node.description,
-              labelType: edge.node.labelType,
-            };
-            return obj;
-          },
-          {}),
+          ...annotator_data.corpus.labelSet.docTypeLabels.edges.reduce(
+            function (obj: Record<string, any>, edge) {
+              obj[edge.node.id] = {
+                id: edge.node.id,
+                color: edge.node.color,
+                text: edge.node.text,
+                icon: edge.node.icon as SemanticICONS,
+                description: edge.node.description,
+                labelType: edge.node.labelType,
+              };
+              return obj;
+            },
+            {}
+          ),
         };
       }
       setDocTypeLabels(Object.values(document_label_lookup));
 
       // Turn existing annotation data into PDFAnnotations obj and inject into state:
-      let annotation_objs = data.existingSpanAnnotations.edges.map(
+      let annotation_objs = annotator_data.existingSpanAnnotations.edges.map(
         (e) =>
           new ServerAnnotation(
             e.node.page,
@@ -371,8 +384,8 @@ export const Annotator = ({
           )
       );
 
-      let doc_type_label_objs = data.existingDocLabelAnnotations.edges.map(
-        (edge) => {
+      let doc_type_label_objs =
+        annotator_data.existingDocLabelAnnotations.edges.map((edge) => {
           let label_obj = edge.node.annotationLabel;
           try {
             label_obj = document_label_lookup[label_obj.id];
@@ -384,11 +397,10 @@ export const Annotator = ({
               : [],
             edge.node.id
           );
-        }
-      );
+        });
 
-      let relationship_label_objs = data.existingRelationships.edges.map(
-        (edge) => {
+      let relationship_label_objs =
+        annotator_data.existingRelationships.edges.map((edge) => {
           let label_obj = edge.node.relationshipLabel;
           if (label_obj) {
             try {
@@ -407,8 +419,7 @@ export const Annotator = ({
             label_obj,
             edge.node.id
           );
-        }
-      );
+        });
 
       // add our loaded annotations from the backend into local state
       setPdfAnnotations(
@@ -422,15 +433,15 @@ export const Annotator = ({
       // Set up contexts for annotations
       setViewState(ViewState.LOADED);
     }
-  }, [data]);
+  }, [annotator_data]);
 
   useEffect(() => {
-    if (error) {
+    if (annotator_error) {
       toast.error(
         "Sorry, something went wrong!\nUnable to fetch required data to open annotations for this document and corpus."
       );
     }
-  }, [error]);
+  }, [annotator_data]);
 
   function addMultipleAnnotations(a: ServerAnnotation[]): void {
     setPdfAnnotations(
@@ -1000,7 +1011,7 @@ export const Annotator = ({
         variables: {
           documentId: openedDocument.id,
           corpusId: openedCorpus.id,
-          annotationLabelId: doc_type.label.id,
+          annotationLabelId: doc_type.annotationLabel.id,
         },
       })
         .then((data) => {

--- a/frontend/src/components/annotator/SearchResult.tsx
+++ b/frontend/src/components/annotator/SearchResult.tsx
@@ -96,7 +96,9 @@ export const SearchResult = ({
             pageInfo={pageInfo}
             tokens={match.tokens[pageInfo.page.pageNumber - 1]}
           />
-        ) : null
+        ) : (
+          <></>
+        )
       }
     </>
   );

--- a/frontend/src/components/annotator/Selection.tsx
+++ b/frontend/src/components/annotator/Selection.tsx
@@ -242,7 +242,7 @@ export const SelectionTokens = ({
 
   return (
     <div ref={containerRef} id="SelectionTokenWrapper">
-      {tokens &&
+      {tokens ? (
         tokens.map((t, i) => {
           const b = pageInfo.getScaledTokenBounds(
             pageInfo.tokens[t.tokenIndex]
@@ -267,7 +267,10 @@ export const SelectionTokens = ({
               }}
             />
           );
-        })}
+        })
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/annotator/SelectionTokens.tsx
+++ b/frontend/src/components/annotator/SelectionTokens.tsx
@@ -37,7 +37,7 @@ export const SelectionTokens = ({
 
   return (
     <div ref={containerRef} id="SelectionTokenWrapper">
-      {tokens &&
+      {tokens ? (
         tokens.map((t, i) => {
           const b = pageInfo.getScaledTokenBounds(
             pageInfo.tokens[t.tokenIndex]
@@ -62,7 +62,10 @@ export const SelectionTokens = ({
               }}
             />
           );
-        })}
+        })
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/annotator/context/AnnotationStore.ts
+++ b/frontend/src/components/annotator/context/AnnotationStore.ts
@@ -157,7 +157,7 @@ export class DocTypeAnnotation {
   public readonly id: string;
 
   constructor(
-    public readonly label: AnnotationLabelType,
+    public readonly annotationLabel: AnnotationLabelType,
     public readonly myPermissions: PermissionTypes[],
     id: string | undefined = undefined
   ) {
@@ -169,7 +169,11 @@ export class DocTypeAnnotation {
   }
 
   static fromObject(obj: DocTypeAnnotation) {
-    return new DocTypeAnnotation(obj.label, obj.myPermissions, obj.id);
+    return new DocTypeAnnotation(
+      obj.annotationLabel,
+      obj.myPermissions,
+      obj.id
+    );
   }
 }
 

--- a/frontend/src/components/annotator/context/PDFStore.ts
+++ b/frontend/src/components/annotator/context/PDFStore.ts
@@ -9,7 +9,19 @@ import { AnnotationLabelType } from "../../../graphql/types";
 import { TokenId, RenderedSpanAnnotation } from "./AnnotationStore";
 import { convertAnnotationTokensToText } from "../utils";
 
+import { type } from "os";
+
 export type Optional<T> = T | undefined;
+
+// Somehow (still trying to figure this one out), undefined tokens are getting
+// passed to getScaledTokenBounds and this is blowing up the entire app. For now,
+// test for undefined token and just return this dummy token json.
+const undefined_bounding_box = {
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+};
 
 /**
  * Returns the provided bounds scaled by the provided factor.
@@ -261,17 +273,29 @@ export class PDFPageInfo {
   }
 
   getScaledTokenBounds(t: Token): BoundingBox {
+    //console.log("getScaledTokenBounds() for t: ", t );
+    if (typeof t === "undefined") {
+      return undefined_bounding_box;
+    }
     return this.getScaledBounds(this.getTokenBounds(t));
   }
 
   getTokenBounds(t: Token): BoundingBox {
-    const b = {
-      left: t.x,
-      top: t.y,
-      right: t.x + t.width,
-      bottom: t.y + t.height,
-    };
-    return b;
+    if (!t) {
+      return {
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+      };
+    } else {
+      return {
+        left: t.x,
+        top: t.y,
+        right: t.x + t.width,
+        bottom: t.y + t.height,
+      };
+    }
   }
 
   getScaledBounds(b: BoundingBox): BoundingBox {

--- a/frontend/src/components/annotator/doc_types/DocTypeLabelDisplay.tsx
+++ b/frontend/src/components/annotator/doc_types/DocTypeLabelDisplay.tsx
@@ -56,23 +56,29 @@ export const DocTypeLabelDisplay = ({ read_only }: { read_only: boolean }) => {
   if (doc_annotations.length === 0) {
     annotation_elements = [<BlankDocTypeLabel key="Blank_LABEL" />];
   } else {
-    annotation_elements = doc_annotations.map((annotation) => (
-      <DocTypeLabel
-        key={annotation.id}
-        onRemove={
-          annotation.myPermissions.includes(PermissionTypes.CAN_REMOVE)
-            ? () => onDelete(annotation)
-            : null
-        }
-        label={annotation.label}
-      />
-    ));
+    for (var annotation of doc_annotations) {
+      try {
+        annotation_elements.push(
+          <DocTypeLabel
+            key={annotation.id}
+            onRemove={
+              annotation.myPermissions.includes(PermissionTypes.CAN_REMOVE)
+                ? () => onDelete(annotation)
+                : null
+            }
+            label={annotation.annotationLabel}
+          />
+        );
+      } catch {}
+    }
   }
 
   // Want to reduce the existing label ids to flat array of just ids...
-  let existing_labels = doc_annotations.map(
-    (annotation) => annotation.label.id
-  );
+  let existing_labels: string[] = [];
+
+  try {
+    doc_annotations.map((annotation) => annotation.annotationLabel.id);
+  } catch {}
 
   // Filter out already applied labels from the label options
   let filtered_doc_label_choices = doc_label_choices.filter(

--- a/frontend/src/components/annotator/doc_types/DocTypeLabels.tsx
+++ b/frontend/src/components/annotator/doc_types/DocTypeLabels.tsx
@@ -7,6 +7,12 @@ interface DocTypeLabelProps {
 }
 
 export const DocTypeLabel = ({ label, onRemove }: DocTypeLabelProps) => {
+  //console.log("DoctTypeLabel for label", label);
+
+  if (!label) {
+    return <></>;
+  }
+
   return (
     <Card
       className="doc_label"
@@ -19,7 +25,7 @@ export const DocTypeLabel = ({ label, onRemove }: DocTypeLabelProps) => {
         margin: ".25vw",
         width: "12vw",
         userSelect: "none",
-        "-msUserSelect": "none",
+        MsUserSelect: "none",
         MozUserSelect: "none",
       }}
     >

--- a/frontend/src/components/annotator/label_selector/LabelElements.tsx
+++ b/frontend/src/components/annotator/label_selector/LabelElements.tsx
@@ -19,7 +19,7 @@ export const LabelElement = ({ label }: DocTypeLabelProps) => {
         margin: ".25vw",
         width: "12vw",
         userSelect: "none",
-        "-msUserSelect": "none",
+        MsUserSelect: "none",
         MozUserSelect: "none",
       }}
     >

--- a/frontend/src/components/annotator/sidebar/AnnotatorSidebar.tsx
+++ b/frontend/src/components/annotator/sidebar/AnnotatorSidebar.tsx
@@ -135,7 +135,7 @@ export const AnnotatorSidebar = ({ read_only }: { read_only: boolean }) => {
     ).map((annotation, index) => {
       return (
         <HighlightItem
-          key={index}
+          key={`highlight_item_${index}`}
           className={annotation.id}
           annotation={annotation}
           read_only={false}
@@ -162,7 +162,7 @@ export const AnnotatorSidebar = ({ read_only }: { read_only: boolean }) => {
 
     return (
       <RelationItem
-        key={relation.id}
+        key={`relation_item_${relation.id}`}
         relation={relation}
         read_only={read_only}
         selected={selectedRelations.includes(relation)}
@@ -290,7 +290,9 @@ export const AnnotatorSidebar = ({ read_only }: { read_only: boolean }) => {
             flex: 1,
           }}
         >
-          <Card.Group key={2}>{relation_elements}</Card.Group>
+          <Card.Group key="relationship_card_group">
+            {relation_elements}
+          </Card.Group>
         </Tab.Pane>
       ),
     },
@@ -326,7 +328,7 @@ export const AnnotatorSidebar = ({ read_only }: { read_only: boolean }) => {
         alignItems: "flex-start",
         justifyContent: "center",
         userSelect: "none",
-        "-msUserSelect": "none",
+        MsUserSelect: "none",
         MozUserSelect: "none",
       }}
     >

--- a/frontend/src/components/annotator/sidebar/RelationItem.tsx
+++ b/frontend/src/components/annotator/sidebar/RelationItem.tsx
@@ -61,7 +61,7 @@ export function RelationItem({
       style={{
         ...(selected ? { backgroundColor: "#e2ffdb" } : {}),
         userSelect: "none",
-        "-msUserSelect": "none",
+        MsUserSelect: "none",
         MozUserSelect: "none",
       }}
       fluid

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -1,0 +1,153 @@
+import { useEffect } from "react";
+import _ from "lodash";
+import { toast } from "react-toastify";
+import { useMutation, useQuery, useReactiveVar } from "@apollo/client";
+import { useLocation } from "react-router-dom";
+
+import { DocumentCards } from "../../components/documents/DocumentCards";
+
+import {
+  selectedDocumentIds,
+  documentSearchTerm,
+  authToken,
+  filterToLabelId,
+} from "../../graphql/cache";
+import {
+  REMOVE_DOCUMENTS_FROM_CORPUS,
+  RemoveDocumentsFromCorpusOutputs,
+  RemoveDocumentsFromCorpusInputs,
+} from "../../graphql/mutations";
+import {
+  RequestDocumentsInputs,
+  RequestDocumentsOutputs,
+  REQUEST_DOCUMENTS,
+} from "../../graphql/queries";
+import { DocumentType } from "../../graphql/types";
+
+export const CorpusDocumentCards = ({
+  opened_corpus_id,
+}: {
+  opened_corpus_id: string | null;
+}) => {
+  /**
+   * Similar to AnnotationCorpusCards, this component wraps the DocumentCards component
+   * (which is a pure rendering component) with some query logic for a given corpus_id.
+   * If the corpus_id is passed in, it will query and display the documents for
+   * that corpus and let you browse them.
+   */
+
+  const document_search_term = useReactiveVar(documentSearchTerm);
+
+  const auth_token = useReactiveVar(authToken);
+  const filter_to_label_id = useReactiveVar(filterToLabelId);
+
+  const location = useLocation();
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Setup document resolvers and mutations
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  const {
+    refetch: refetchDocuments,
+    loading: documents_loading,
+    error: documents_error,
+    data: documents_response,
+    fetchMore: fetchMoreDocuments,
+  } = useQuery<RequestDocumentsOutputs, RequestDocumentsInputs>(
+    REQUEST_DOCUMENTS,
+    {
+      variables: {
+        ...(opened_corpus_id
+          ? { annotateDocLabels: true, inCorpusWithId: opened_corpus_id }
+          : { annotateDocLabels: false }),
+        ...(filter_to_label_id ? { hasLabelWithId: filter_to_label_id } : {}),
+        ...(document_search_term ? { textSearch: document_search_term } : {}),
+      },
+      notifyOnNetworkStatusChange: true, // necessary in order to trigger loading signal on fetchMore
+    }
+  );
+  if (documents_error) {
+    toast.error("ERROR\nCould not fetch documents for corpus.");
+  }
+
+  useEffect(() => {
+    refetchDocuments();
+  }, [document_search_term]);
+
+  const [removeDocumentsFromCorpus, {}] = useMutation<
+    RemoveDocumentsFromCorpusOutputs,
+    RemoveDocumentsFromCorpusInputs
+  >(REMOVE_DOCUMENTS_FROM_CORPUS, {
+    onCompleted: () => {
+      refetchDocuments();
+    },
+  });
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Effects to reload data on certain changes
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // If user logs in while on this page... refetch to get their authorized corpuses
+  useEffect(() => {
+    console.log("Auth token change", auth_token);
+    if (auth_token && opened_corpus_id) {
+      refetchDocuments();
+    }
+  }, [auth_token]);
+
+  useEffect(() => {
+    if (filter_to_label_id) {
+      refetchDocuments();
+    }
+  }, [filter_to_label_id]);
+
+  // If we detech user navigated to this page, refetch
+  useEffect(() => {
+    if (opened_corpus_id && location.pathname === "/corpuses") {
+      refetchDocuments();
+    }
+  }, [location]);
+
+  useEffect(() => {
+    if (opened_corpus_id) {
+      refetchDocuments();
+    }
+  }, [opened_corpus_id]);
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Query to shape item data
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  const document_data = documents_response?.documents?.edges
+    ? documents_response.documents.edges
+    : [];
+  const document_items = document_data
+    .map((edge) => (edge?.node ? edge.node : undefined))
+    .filter((item): item is DocumentType => !!item);
+
+  const handleRemoveContracts = (delete_ids: string[]) => {
+    removeDocumentsFromCorpus({
+      variables: {
+        corpusId: opened_corpus_id ? opened_corpus_id : "",
+        documentIdsToRemove: delete_ids,
+      },
+    })
+      .then(() => {
+        selectedDocumentIds([]);
+        toast.success("SUCCESS! Contracts removed.");
+      })
+      .catch(() => {
+        selectedDocumentIds([]);
+        toast.error("ERROR! Contract removal failed.");
+      });
+  };
+
+  return (
+    <DocumentCards
+      items={document_items}
+      loading={documents_loading}
+      loading_message="Documents Loading..."
+      pageInfo={documents_response?.documents.pageInfo}
+      style={{ minHeight: "70vh" }}
+      fetchMore={fetchMoreDocuments}
+      removeFromCorpus={opened_corpus_id ? handleRemoveContracts : undefined}
+    />
+  );
+};

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useEffect, ReactNode } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Tab } from "semantic-ui-react";
-import _ from "lodash";
+import _, { update } from "lodash";
 import { toast } from "react-toastify";
 import {
   useLazyQuery,
@@ -19,9 +19,7 @@ import {
 import { CRUDModal } from "../components/widgets/CRUD/CRUDModal";
 import { CardLayout } from "../components/layout/CardLayout";
 import { CorpusBreadcrumbs } from "../components/corpuses/CorpusBreadcrumbs";
-import { DocumentCards } from "../components/documents/DocumentCards";
 import { LabelSetSelector } from "../components/widgets/CRUD/LabelSetSelector";
-import { AnnotationCards } from "../components/annotations/AnnotationCards";
 import {
   newCorpusForm_Ui_Schema,
   newCorpusForm_Schema,
@@ -40,7 +38,6 @@ import {
   documentSearchTerm,
   authToken,
   annotationContentSearchTerm,
-  filterToLabelsetId,
   openedDocument,
   showSelectedAnnotationOnly,
   showAnnotationBoundingBoxes,
@@ -66,26 +63,20 @@ import {
   START_IMPORT_CORPUS,
 } from "../graphql/mutations";
 import {
-  GetAnnotationsInputs,
-  GetAnnotationsOutputs,
   GetCorpusesInputs,
   GetCorpusesOutputs,
-  GET_ANNOTATIONS,
   GET_CORPUSES,
   RequestDocumentsInputs,
   RequestDocumentsOutputs,
   REQUEST_DOCUMENTS,
 } from "../graphql/queries";
-import {
-  ServerAnnotationType,
-  CorpusType,
-  DocumentType,
-  LabelType,
-} from "../graphql/types";
+import { CorpusType, LabelType } from "../graphql/types";
 import { LooseObject } from "../components/types";
 import { Annotator } from "../components/annotator/Annotator";
 import { toBase64 } from "../utils/files";
 import { FilterToLabelSelector } from "../components/widgets/model-filters/FilterToLabelSelector";
+import { CorpusAnnotationCards } from "../components/annotations/CorpusAnnotationCards";
+import { CorpusDocumentCards } from "../components/documents/CorpusDocumentCards";
 
 export const Corpuses = () => {
   const show_remove_docs_from_corpus_modal = useReactiveVar(
@@ -107,11 +98,10 @@ export const Corpuses = () => {
     showAnnotationBoundingBoxes
   );
   const show_annotation_labels = useReactiveVar(showAnnotationLabels);
+  const filter_to_label_id = useReactiveVar(filterToLabelId);
 
   const auth_token = useReactiveVar(authToken);
   const annotation_search_term = useReactiveVar(annotationContentSearchTerm);
-  const filter_to_labelset_id = useReactiveVar(filterToLabelsetId);
-  const filter_to_label_id = useReactiveVar(filterToLabelId);
 
   const location = useLocation();
 
@@ -173,42 +163,6 @@ export const Corpuses = () => {
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Setup document resolvers and mutations
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  const [
-    fetchDocuments,
-    {
-      refetch: refetchDocuments,
-      loading: documents_loading,
-      error: documents_error,
-      data: documents_response,
-      fetchMore: fetchMoreDocuments,
-    },
-  ] = useLazyQuery<RequestDocumentsOutputs, RequestDocumentsInputs>(
-    REQUEST_DOCUMENTS,
-    {
-      variables: {
-        ...(opened_corpus
-          ? { annotateDocLabels: true, inCorpusWithId: opened_corpus.id }
-          : { annotateDocLabels: false }),
-        ...(filter_to_label_id ? { hasLabelWithId: filter_to_label_id } : {}),
-        ...(document_search_term ? { textSearch: document_search_term } : {}),
-      },
-      notifyOnNetworkStatusChange: true, // necessary in order to trigger loading signal on fetchMore
-    }
-  );
-
-  useEffect(() => {
-    refetchDocuments();
-  }, [document_search_term]);
-
-  const [removeDocumentsFromCorpus, {}] = useMutation<
-    RemoveDocumentsFromCorpusOutputs,
-    RemoveDocumentsFromCorpusInputs
-  >(REMOVE_DOCUMENTS_FROM_CORPUS, {
-    onCompleted: () => {
-      refetchDocuments();
-    },
-  });
-
   const [startImportCorpus, {}] = useMutation<
     StartImportCorpusExport,
     StartImportCorpusInputs
@@ -230,49 +184,44 @@ export const Corpuses = () => {
     loading: loading_corpuses,
     error: corpus_load_error,
     data: corpus_response,
-    fetchMore: fetchMoreCorpuses,
+    fetchMore: fetchMoreCorpusesOrig,
   } = useQuery<GetCorpusesOutputs, GetCorpusesInputs>(GET_CORPUSES, {
     variables: corpus_variables,
     notifyOnNetworkStatusChange: true, // required to get loading signal on fetchMore
   });
+
   if (corpus_load_error) {
     toast.error("ERROR\nUnable to fetch corpuses.");
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // Query to get annotations
+  // Query to refetch documents if dropdown action is used to delink a doc from corpus
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  const [
-    fetchAnnotations,
-    {
-      refetch: refetchAnnotations,
-      loading: annotation_loading,
-      error: annotation_error,
-      data: annotation_response,
-      fetchMore: fetchMoreAnnotations,
+  const [fetchDocumentsLazily, { error: documents_error }] = useLazyQuery<
+    RequestDocumentsOutputs,
+    RequestDocumentsInputs
+  >(REQUEST_DOCUMENTS, {
+    variables: {
+      ...(opened_corpus_id
+        ? { annotateDocLabels: true, inCorpusWithId: opened_corpus_id }
+        : { annotateDocLabels: false }),
+      ...(filter_to_label_id ? { hasLabelWithId: filter_to_label_id } : {}),
+      ...(document_search_term ? { textSearch: document_search_term } : {}),
     },
-  ] = useLazyQuery<GetAnnotationsOutputs, GetAnnotationsInputs>(
-    GET_ANNOTATIONS,
-    {
-      notifyOnNetworkStatusChange: true, // necessary in order to trigger loading signal on fetchMore
-      variables: {
-        annotationLabel_Type: "TOKEN_LABEL",
-        ...(opened_corpus ? { corpusId: opened_corpus.id } : {}),
-        ...(filter_to_label_id
-          ? { annotationLabelId: filter_to_label_id }
-          : {}),
-        ...(filter_to_labelset_id
-          ? { usesLabelFromLabelsetId: filter_to_labelset_id }
-          : {}),
-        ...(annotation_search_term
-          ? { rawText_Contains: annotation_search_term }
-          : {}),
-      },
-    }
-  );
-  if (annotation_error) {
-    toast.error("ERROR\nCould not fetch annotations.");
+    notifyOnNetworkStatusChange: true, // necessary in order to trigger loading signal on fetchMore
+  });
+  if (documents_error) {
+    toast.error("ERROR\nCould not fetch documents for corpus.");
   }
+
+  useEffect(() => {
+    console.log("Corpuses.tsx - Loading Corpuses changed...");
+  }, [loading_corpuses]);
+
+  const fetchMoreCorpuses = (args: any) => {
+    console.log("Corpuses.txt - fetchMoreCorpuses()");
+    fetchMoreCorpusesOrig(args);
+  };
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Effects to reload data on certain changes
@@ -281,103 +230,36 @@ export const Corpuses = () => {
   useEffect(() => {
     if (auth_token) {
       refetchCorpuses();
-      if (opened_corpus) {
-        refetchDocuments();
-        refetchAnnotations();
-      }
     }
   }, [auth_token]);
 
-  // If the tab changes, refetch appropriate data for selected tab
   useEffect(() => {
-    switch (active_tab) {
-      case 0:
-        refetchDocuments();
-        break;
-      case 1:
-        refetchAnnotations();
-        break;
-      default:
-        break;
-    }
-  }, [active_tab]);
-
-  useEffect(() => {
+    console.log("corpus_search_term");
     refetchCorpuses();
   }, [corpus_search_term]);
 
-  useEffect(() => {
-    console.log("Apple");
-    if (filter_to_label_id) {
-      switch (active_tab) {
-        case 0:
-          refetchDocuments();
-          break;
-        case 1:
-          refetchAnnotations();
-          break;
-        default:
-          console.log(`Unexpected tab index: ${active_tab}`);
-      }
-    }
-  }, [filter_to_label_id]);
-
   // If we detech user navigated to this page, refetch
   useEffect(() => {
-    refetchCorpuses().then(() => {
-      if (opened_corpus) {
-        fetchDocuments();
-        refetchAnnotations();
-      }
-    });
+    if (location.pathname === "/corpuses") {
+      refetchCorpuses();
+    }
   }, [location]);
 
   useEffect(() => {
-    console.log("Opened corpus");
-    if (opened_corpus_id) {
-      console.log("Fetch docs and annotations");
-      refetchDocuments();
-      refetchAnnotations();
-    } else {
-      console.log("Fetch corpuses");
+    if (!opened_corpus_id) {
       refetchCorpuses();
     }
-  }, [opened_corpus_id, refetchCorpuses, fetchDocuments, fetchAnnotations]);
-
-  useEffect(() => {
-    refetchAnnotations();
-  }, [annotation_search_term]);
-
-  useEffect(() => {
-    fetchDocuments();
-    if (active_tab === 1) {
-      fetchAnnotations();
-    }
-  }, []);
+  }, [opened_corpus_id]);
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Query to shape item data
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  const annotation_data = annotation_response?.annotations?.edges
-    ? annotation_response.annotations.edges
-    : [];
-  const annotation_items = annotation_data
-    .map((edge) => (edge ? edge.node : undefined))
-    .filter((item): item is ServerAnnotationType => !!item);
-
   const corpus_data = corpus_response?.corpuses?.edges
     ? corpus_response.corpuses.edges
     : [];
   const corpus_items = corpus_data
     .map((edge) => (edge ? edge.node : undefined))
     .filter((item): item is CorpusType => !!item);
-
-  const document_data = documents_response?.documents?.edges
-    ? documents_response.documents.edges
-    : [];
-  const document_items = document_data
-    .map((edge) => (edge?.node ? edge.node : undefined))
-    .filter((item): item is DocumentType => !!item);
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Query to mutate corpus
@@ -401,6 +283,15 @@ export const Corpuses = () => {
   >(DELETE_CORPUS, {
     onCompleted: (data) => {
       refetchCorpuses();
+    },
+  });
+
+  const [removeDocumentsFromCorpus, {}] = useMutation<
+    RemoveDocumentsFromCorpusOutputs,
+    RemoveDocumentsFromCorpusInputs
+  >(REMOVE_DOCUMENTS_FROM_CORPUS, {
+    onCompleted: () => {
+      fetchDocumentsLazily();
     },
   });
 
@@ -441,7 +332,7 @@ export const Corpuses = () => {
     }
   };
 
-  // TODO - Implement; Improve typing.
+  // TODO - Improve typing.
   const handleUpdateCorpus = (corpus_obj: any) => {
     // console.log("handleUpdateCorpus", corpus_obj);
     let variables = {
@@ -451,7 +342,7 @@ export const Corpuses = () => {
     tryMutateCorpus(variables);
   };
 
-  // TODO - Implement; Improve typing.
+  // TODO - Improve typing.
   const handleDeleteCorpus = (corpus_id: string | undefined) => {
     if (corpus_id) {
       // console.log("handleDeleteCorpus", corpus_id)
@@ -465,7 +356,6 @@ export const Corpuses = () => {
     }
   };
 
-  // TODO - Implement.
   const handleRemoveContracts = (delete_ids: string[]) => {
     // console.log("handleRemoveContracts", delete_ids);
     removeDocumentsFromCorpus({
@@ -484,7 +374,7 @@ export const Corpuses = () => {
       });
   };
 
-  // TODO - Implement; Improve typing.
+  // TODO - Improve typing.
   const handleCreateNewCorpus = (corpus_json: Record<string, any>) => {
     tryCreateCorpus({ variables: corpus_json })
       .then((data) => {
@@ -524,7 +414,7 @@ export const Corpuses = () => {
   }
 
   let contract_actions: DropdownActionProps[] = [];
-  if (selected_document_ids.length > 0 && authToken) {
+  if (selected_document_ids.length > 0 && auth_token) {
     contract_actions.push({
       icon: "remove circle",
       title: "Remove Contract(s)",
@@ -539,15 +429,7 @@ export const Corpuses = () => {
       menuItem: "Contracts",
       render: () => (
         <Tab.Pane>
-          <DocumentCards
-            items={document_items}
-            loading={documents_loading}
-            loading_message="Documents Loading..."
-            pageInfo={documents_response?.documents.pageInfo}
-            style={{ minHeight: "70vh" }}
-            fetchMore={fetchMoreDocuments}
-            removeFromCorpus={opened_corpus ? handleRemoveContracts : undefined}
-          />
+          <CorpusDocumentCards opened_corpus_id={opened_corpus_id} />
         </Tab.Pane>
       ),
     },
@@ -555,18 +437,83 @@ export const Corpuses = () => {
       menuItem: "Annotations",
       render: () => (
         <Tab.Pane>
-          <AnnotationCards
-            items={annotation_items}
-            loading={annotation_loading}
-            loading_message="Annotations Loading..."
-            pageInfo={annotation_response?.annotations.pageInfo}
-            style={{ minHeight: "70vh" }}
-            fetchMore={fetchMoreAnnotations}
-          />
+          <CorpusAnnotationCards opened_corpus_id={opened_corpus_id} />
         </Tab.Pane>
       ),
     },
   ];
+
+  let content = <></>;
+
+  // These else if statements should really be broken into separate components.
+  //console.log(`Opened_corpus`, opened_corpus, 'opened_document', opened_document);
+
+  if (
+    (opened_corpus === null || opened_corpus === undefined) &&
+    (opened_document === null || opened_document === undefined)
+  ) {
+    console.log("Set content to CorpusCards");
+    content = (
+      <CorpusCards
+        items={corpus_items}
+        pageInfo={corpus_response?.corpuses?.pageInfo}
+        loading={
+          loading_corpuses ||
+          delete_corpus_loading ||
+          update_corpus_loading ||
+          create_corpus_loading
+        }
+        loading_message="Loading Corpuses..."
+        fetchMore={fetchMoreCorpuses}
+      />
+    );
+  } else if (
+    (opened_corpus !== null || opened_corpus !== undefined) &&
+    (opened_document === null || opened_document === undefined)
+  ) {
+    console.log("Set content to tab");
+    content = (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "center",
+          height: "100%",
+          marginLeft: "1rem",
+          marginRight: "1rem",
+        }}
+      >
+        <Tab
+          attached="bottom"
+          style={{ width: "100%" }}
+          activeIndex={active_tab}
+          onTabChange={(e, { activeIndex }) =>
+            setActiveTab(activeIndex ? Number(activeIndex) : 0)
+          }
+          panes={panes}
+        />
+      </div>
+    );
+  } else if (
+    opened_corpus !== null &&
+    opened_corpus !== undefined &&
+    opened_document !== null &&
+    opened_document !== undefined
+  ) {
+    console.log("Reset Annotator ref");
+    content = (
+      <Annotator
+        open={Boolean(opened_document)}
+        onClose={() => openedDocument(null)}
+        openedDocument={opened_document}
+        openedCorpus={opened_corpus}
+        scroll_to_annotation_on_open={opened_to_annotation}
+        show_selected_annotation_only={show_selected_annotation_only}
+        show_annotation_bounding_boxes={show_annotation_bounding_boxes}
+        show_annotation_labels={show_annotation_labels}
+      />
+    );
+  }
 
   return (
     <CardLayout
@@ -714,49 +661,7 @@ export const Corpuses = () => {
         type="file"
         onChange={onImportFileChange}
       />
-      {opened_corpus !== null ? (
-        opened_document === null ? (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              height: "100%",
-              marginLeft: "1rem",
-              marginRight: "1rem",
-            }}
-          >
-            <Tab
-              attached="bottom"
-              style={{ width: "100%" }}
-              activeIndex={active_tab}
-              onTabChange={(e, { activeIndex }) =>
-                setActiveTab(activeIndex ? Number(activeIndex) : 0)
-              }
-              panes={panes}
-            />
-          </div>
-        ) : (
-          <Annotator
-            open={Boolean(opened_document)}
-            onClose={() => openedDocument(null)}
-            openedDocument={opened_document}
-            openedCorpus={opened_corpus}
-            scroll_to_annotation_on_open={opened_to_annotation}
-            show_selected_annotation_only={show_selected_annotation_only}
-            show_annotation_bounding_boxes={show_annotation_bounding_boxes}
-            show_annotation_labels={show_annotation_labels}
-          />
-        )
-      ) : (
-        <CorpusCards
-          items={corpus_items}
-          pageInfo={corpus_response?.corpuses?.pageInfo}
-          loading={loading_corpuses}
-          loading_message="Loading Corpuses..."
-          fetchMore={fetchMoreCorpuses}
-        />
-      )}
+      {content}
     </CardLayout>
   );
 };


### PR DESCRIPTION
Things got a bit messy in the old private repo I was working in. Corpuses.tsx had too many things going on in it and it got messy to maintain. There was also a problem where opening a document in the Annotator would trigger another lazyQuery to trigger which would trigger a reload which would trigger the original query which would trigger the lazyQuery... and so on and so on. Broke a bunch of Corpuses.tsx out into new components. Also a lot of general clean-up in here. 